### PR TITLE
bugfix/NLRFIM-76 - NotOnOrAfter validation

### DIFF
--- a/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
@@ -210,6 +210,8 @@ namespace dk.nita.saml20.protocol
                 }
                 else
                 {
+                    ValidateNotOnOrAfter(context, parser.LogoutRequest);
+                    
                     Saml20MetadataDocument metadata = idp.metadata;
 
                     if (!parser.CheckSignature(metadata.GetKeys(KeyTypes.signing)))

--- a/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
@@ -671,7 +671,7 @@ namespace dk.nita.saml20.protocol
                 }
                 else
                 {
-                    Trace.TraceData(TraceEventType.Warning, "The user was logged out but the session had already expired. Distributed session could therefore not be abandonded�");
+                    Trace.TraceData(TraceEventType.Warning, "The user was logged out but the session had already expired. Distributed session could therefore not be abandoned");
                 }
             }
         }

--- a/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
@@ -634,7 +634,7 @@ namespace dk.nita.saml20.protocol
             if (notOnOrAfter.AddMinutes(allowedClockSkewTime) > now) 
                 return;
             
-            var errormessage = $"Logout request expired. NotOnOrAfter={notOnOrAfter}, RequestReceived={allowedClockSkewTime}";
+            var errormessage = $"Logout request expired. NotOnOrAfter={notOnOrAfter}, RequestReceived={now}";
             AuditLogging.logEntry(Direction.IN, Operation.LOGOUTREQUEST, errormessage);
             HandleError(context, errormessage);
         }

--- a/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
@@ -624,19 +624,24 @@ namespace dk.nita.saml20.protocol
         /// <exception cref="Saml20Exception">Throws Saml20Exception if validation fails, and config is set to throw exception.</exception>
         private void ValidateNotOnOrAfter(HttpContext context, LogoutRequest logoutRequest)
         {
-            if (!logoutRequest.NotOnOrAfter.HasValue) 
+            if (!logoutRequest.NotOnOrAfter.HasValue)
+            {
                 return;
-            
+            }
+
             var notOnOrAfter = logoutRequest.NotOnOrAfter.Value;
             var allowedClockSkewTime = FederationConfig.GetConfig().AllowedClockSkewMinutes;
             var now = DateTime.UtcNow;
-            
-            if (notOnOrAfter.AddMinutes(allowedClockSkewTime) > now) 
+
+            if (notOnOrAfter.AddMinutes(allowedClockSkewTime) > now)
+            {
                 return;
-            
+            }
+
             var errormessage = $"Logout request expired. NotOnOrAfter={notOnOrAfter}, RequestReceived={now}";
             AuditLogging.logEntry(Direction.IN, Operation.LOGOUTREQUEST, errormessage);
             HandleError(context, errormessage);
+            
         }
 
         #endregion

--- a/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
@@ -523,19 +523,7 @@ namespace dk.nita.saml20.protocol
                     return;
                 }
 
-                if (logoutRequest.NotOnOrAfter.HasValue)
-                {
-                    var allowedClockSkewTime = DateTime.UtcNow.AddMinutes(FederationConfig.GetConfig().AllowedClockSkewMinutes);
-
-                    if (logoutRequest.NotOnOrAfter >= allowedClockSkewTime)
-                    {
-                        var errormessage =
-                            $"Logout request NotOnOrAfter ({logoutRequest.NotOnOrAfter}) is after allowed time ({allowedClockSkewTime})";
-                        AuditLogging.logEntry(Direction.IN, Operation.LOGOUTREQUEST, errormessage);
-                        HandleError(context, errormessage);
-                        return;
-                    }
-                }
+                ValidateNotOnOrAfter(context, logoutRequest); // Throws if not valid.
                 
                 Saml20MetadataDocument metadata = endpoint.metadata;
 
@@ -621,6 +609,31 @@ namespace dk.nita.saml20.protocol
                 return;
             }
         }
+        
+        /// <summary>
+        /// Validates that the <see cref="LogoutRequest"/> has not expired, by checking that NotOnOrAfter + allowedTimeSkew is greater than current time.
+        /// Only validated if <see cref="LogoutRequest.NotOnOrAfter"/> is not null.
+        /// </summary>
+        /// <param name="context">The requests <see cref="HttpContext"/></param>
+        /// <param name="logoutRequest">The LogoutRequest to validate</param>
+        /// <exception cref="T:System.Threading.ThreadAbortException">Throws ThreadAbortException if validation fails, and config is set to show an error page.</exception>
+        /// <exception cref="Saml20Exception">Throws Saml20Exception if validation fails, and config is set to throw exception.</exception>
+        private void ValidateNotOnOrAfter(HttpContext context, LogoutRequest logoutRequest)
+        {
+            if (!logoutRequest.NotOnOrAfter.HasValue) 
+                return;
+            
+            var notOnOrAfter = logoutRequest.NotOnOrAfter.Value;
+            var allowedClockSkewTime = FederationConfig.GetConfig().AllowedClockSkewMinutes;
+            var now = DateTime.UtcNow;
+            
+            if (notOnOrAfter.AddMinutes(allowedClockSkewTime) > now) 
+                return;
+            
+            var errormessage = $"Logout request expired. NotOnOrAfter={notOnOrAfter}, RequestReceived={allowedClockSkewTime}";
+            AuditLogging.logEntry(Direction.IN, Operation.LOGOUTREQUEST, errormessage);
+            HandleError(context, errormessage);
+        }
 
         #endregion
 
@@ -656,7 +669,7 @@ namespace dk.nita.saml20.protocol
                 }
                 else
                 {
-                    Trace.TraceData(TraceEventType.Warning, "The user was logged out but the session had already expired. Distributed session could therefore not be abandonded½");
+                    Trace.TraceData(TraceEventType.Warning, "The user was logged out but the session had already expired. Distributed session could therefore not be abandondedï¿½");
                 }
             }
         }

--- a/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20LogoutHandler.cs
@@ -491,6 +491,8 @@ namespace dk.nita.saml20.protocol
                     return;
                 }
 
+                ValidateNotOnOrAfter(context, logoutRequest); // Throws if not valid.
+                
                 Saml20MetadataDocument metadata = endpoint.metadata;
 
                 if (!parser.VerifySignature(metadata.GetKeys(KeyTypes.signing)))


### PR DESCRIPTION
Suggested fix for Issue #33.

This PR contains:
1. Fixing issue where AllowedClockSkewMinutes would narrow the valid window rather than extending it.
2. Extracting the validation logic into its own method.
3. Added missing NotOnOrAfter validation to GET binding.
4. Added missing NotOnOrAfter validation to SOAP binding.
5. Fixed minor spelling mistake.