### PR TITLE
When comparison has been specfied - ComparisonSpecified wil be set.

### DIFF
--- a/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20SignonHandler.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20SignonHandler.cs
@@ -830,6 +830,7 @@ namespace dk.nita.saml20.protocol
             {
                 request.Request.RequestedAuthnContext = new RequestedAuthnContext();
                 request.Request.RequestedAuthnContext.Comparison = AuthnContextComparisonType.minimum;
+                request.Request.RequestedAuthnContext.ComparisonSpecified = true;
                 request.Request.RequestedAuthnContext.ItemsElementName = requestContextItems.Select(x => x.type).ToArray();
                 request.Request.RequestedAuthnContext.Items = requestContextItems.Select(x => x.value).ToArray();
             }


### PR DESCRIPTION
When comparison has been specied - ComparisonSpecified wil be set. Otherwise the error "If LoA is specified, then it must be used with the Comparison attribute set to minimum" will be returned when demainding a specific LoA.