### PR TITLE
Added .net framework supported encryption angorithms

### DIFF
--- a/src/dk.nita.saml20/dk.nita.saml20/Saml20MetadataDocument.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Saml20MetadataDocument.cs
@@ -78,7 +78,7 @@ namespace dk.nita.saml20
             spDescriptor.protocolSupportEnumeration = new string[] { Saml20Constants.PROTOCOL };
             spDescriptor.AuthnRequestsSigned = XmlConvert.ToString(true);
             spDescriptor.WantAssertionsSigned = XmlConvert.ToString(true);
-         
+
             Uri baseURL = new Uri(config.ServiceProvider.Server);
             List<Endpoint> logoutServiceEndpoints = new List<Endpoint>();
             List<IndexedEndpoint> signonServiceEndpoints = new List<IndexedEndpoint>();
@@ -195,6 +195,11 @@ namespace dk.nita.saml20
 
                 keyEncryption.use = KeyTypes.encryption;
                 keyEncryption.useSpecified = true;
+                keyEncryption.EncryptionMethod = new Schema.XEnc.EncryptionMethod[]
+                {
+                    new Schema.XEnc.EncryptionMethod{Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc" },
+                    new Schema.XEnc.EncryptionMethod{Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p" }
+                };
 
                 // Ugly conversion between the .Net framework classes and our classes ... avert your eyes!!
                 keySigning.KeyInfo = Serialization.DeserializeFromXmlString<Schema.XmlDSig.KeyInfo>(keyinfo.GetXml().OuterXml);


### PR DESCRIPTION
Added .net framework supported encryption angorithms to prevent idp from using rsa-oaep as described in https://www.digitaliser.dk/news/6072243. After this, is is no longer necessary to modify the generated metadata for the Service Provider before uploading to the NemLog-in Administration