### PR TITLE
Removed new loa level (low) from legacy loa selection (3). 

### DIFF
--- a/src/dk.nita.saml20/IdentityProviderDemo/SignonForm.aspx.cs
+++ b/src/dk.nita.saml20/IdentityProviderDemo/SignonForm.aspx.cs
@@ -120,7 +120,6 @@ namespace IdentityProviderDemo
             if (LoaLegacy.Checked)
             {
                 user.DynamicAttributes.Add(new KeyValuePair<string, string>(DKSaml20AssuranceLevelAttribute.NAME, "3"));
-                user.DynamicAttributes.Add(new KeyValuePair<string, string>(DKSaml20NsisLoaAttribute.NAME, LoaLow.Text));
             }
             else
             {


### PR DESCRIPTION
Removed the new loa level (low) when the user selects loa level 3 in the idp. This is to align the returned attributes with the ones returned from the NemLog-in OIOSAML 3.0 IDP.