### PR TITLE
REF-11 Harden metadata directory handling (#25, #24)

### DIFF
--- a/src/dk.nita.saml20/dk.nita.saml20/Config/SAML20FederationConfig.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Config/SAML20FederationConfig.cs
@@ -479,6 +479,8 @@ namespace dk.nita.saml20.config
         private void HandleUpdateIdp(string filename)
         {
             var metadataDoc = ParseFile(filename);
+            if (metadataDoc == null)
+                return; // Not a SAML 2.0 metadata file - ignore it instead of failing.
             // First we try and find the endpoint based on the entity id in the metadata
             var endp = FindEndPoint(metadataDoc.EntityId);
             if (endp == null && _fileToEntity.ContainsKey(filename))
@@ -501,6 +503,8 @@ namespace dk.nita.saml20.config
             if (!_fileToEntity.ContainsKey(filename))
             {
                 var metadataDoc = ParseFile(filename);
+                if (metadataDoc == null)
+                    return; // Not a SAML 2.0 metadata file (e.g. a README placed in the metadata directory) - ignore it instead of failing.
                 var endp = FindEndPoint(metadataDoc.EntityId);
                 if (endp == null) // If the endpoint does not exist, create it.
                 {

--- a/src/dk.nita.saml20/dk.nita.saml20/Properties/Resources.Designer.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Properties/Resources.Designer.cs
@@ -755,7 +755,7 @@ namespace Saml2.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Metadata not found for idp endpoint with id {0}.
+        ///   Looks up a localized string similar to No metadata was found for the configured IDPEndpoint with id &quot;{0}&quot;. Verify that the id matches the entityID of a metadata file in the configured metadata directory (a misspelled id is the most common cause).
         /// </summary>
         internal static string MetadataNotFound {
             get {

--- a/src/dk.nita.saml20/dk.nita.saml20/Properties/Resources.resx
+++ b/src/dk.nita.saml20/dk.nita.saml20/Properties/Resources.resx
@@ -334,7 +334,7 @@ AppID={1}</value>
     <value>The specified metadata directory "{0}" could not be located.</value>
   </data>
   <data name="MetadataNotFound" xml:space="preserve">
-    <value>Metadata not found for idp endpoint with id {0}</value>
+    <value>No metadata was found for the configured IDPEndpoint with id "{0}". Verify that the id matches the entityID of a metadata file in the configured metadata directory (a misspelled id is the most common cause).</value>
   </data>
   <data name="NoAttributeValuePresent" xml:space="preserve">
     <value>Xml error: attribute {0} of element {1}: {2} must have a value.</value>

--- a/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20AbstractEndpointHandler.cs
+++ b/src/dk.nita.saml20/dk.nita.saml20/Protocol/Saml20AbstractEndpointHandler.cs
@@ -9,6 +9,7 @@ using dk.nita.saml20.Logging;
 using dk.nita.saml20.Properties;
 using dk.nita.saml20.Schema.Protocol;
 using dk.nita.saml20.Utils;
+using Saml2.Properties;
 using Trace = dk.nita.saml20.Utils.Trace;
 
 namespace dk.nita.saml20.protocol
@@ -142,6 +143,11 @@ namespace dk.nita.saml20.protocol
             var defaultIdp = config.Endpoints.IDPEndPoints.Find(idp => idp.Default);
             if (defaultIdp != null)
             {
+                // A configured endpoint has no metadata when no metadata file matches its id (typically a misspelled
+                // id). Fail with a clear message instead of the opaque NullReferenceException that follows downstream.
+                if (defaultIdp.metadata == null)
+                    throw new Saml20Exception(string.Format(Resources.MetadataNotFound, defaultIdp.Id));
+
                 if (Trace.ShouldTrace(TraceEventType.Information))
                     Trace.TraceData(TraceEventType.Information, "Using IdP marked as default: " + defaultIdp.Id);
 


### PR DESCRIPTION
Follow-up to #81, which was merged before these two commits landed on the branch. This PR carries the remaining metadata-directory robustness fixes.

## Changes

- **#25 — Non-metadata files break config load.** `ParseFile` returns `null` for a file that isn't SAML 2.0 metadata, but `HandleCreateIdp`/`HandleUpdateIdp` dereferenced it immediately, throwing a `NullReferenceException` that aborted configuration loading (e.g. a `README` placed in the metadata directory). Such files are now skipped gracefully; `ParseFile` already traces the reason. Also resolves the intermittent NRE in #72.
- **#24 — Misspelled default IDPEndpoint id.** A misspelled `id` leaves the configured endpoint's `metadata` null; when selected as the default, `RetrieveIDP` returned it and the caller hit an opaque `NullReferenceException`. Now throws a descriptive `Saml20Exception` naming the id, reusing the previously-unused `MetadataNotFound` resource (reworded to point at the likely misspelling).

## Notes

- The #24 check is placed at point-of-use (`RetrieveIDP`) rather than in `IDPEndpoints.Initialize()`: the test config intentionally declares endpoints without matching metadata files, and `Initialize()` runs on every config load, so a load-time throw would break the test suite.

## Testing

CI (`build-and-test`) passing on the head commit. No cross-platform build path exists locally (Windows/msbuild only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)